### PR TITLE
Update cookbook lib URLs

### DIFF
--- a/cookbook/index.html
+++ b/cookbook/index.html
@@ -8,7 +8,7 @@
         <meta name="msapplication-tap-highlight" content="no">
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
-        <script src="../dist/ionic-vue.js"></script>
+        <script src="https://unpkg.com/@modus/ionic-vue@1.0.0/dist/ionic-vue.js"></script>
         <script src="https://unpkg.com/@ionic/core@4.0.0-beta.0/dist/ionic.js"></script>
         <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.0/css/ionic.min.css"/>
     </head>

--- a/cookbook/ion-nav-routing.html
+++ b/cookbook/ion-nav-routing.html
@@ -8,7 +8,7 @@
         <meta name="msapplication-tap-highlight" content="no">
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
-        <script src="../dist/ionic-vue.js"></script>
+        <script src="https://unpkg.com/@modus/ionic-vue@1.0.0/dist/ionic-vue.js"></script>
         <script src="https://unpkg.com/@ionic/core@4.0.0-beta.0/dist/ionic.js"></script>
         <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.0/css/ionic.min.css"/>
     </head>

--- a/cookbook/named-views.html
+++ b/cookbook/named-views.html
@@ -8,7 +8,7 @@
         <meta name="msapplication-tap-highlight" content="no">
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
-        <script src="../dist/ionic-vue.js"></script>
+        <script src="https://unpkg.com/@modus/ionic-vue@1.0.0/dist/ionic-vue.js"></script>
         <script src="https://unpkg.com/@ionic/core@4.0.0-beta.0/dist/ionic.js"></script>
         <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.0/css/ionic.min.css"/>
     </head>


### PR DESCRIPTION
Change to unpkg when loading the ionic-vue lib within the cookbook examples