### PR TITLE
Allow direction override

### DIFF
--- a/src/components/ion-vue-router.vue
+++ b/src/components/ion-vue-router.vue
@@ -66,6 +66,10 @@ export default {
 
       let defaultHref
 
+      // Explicitly override router direction
+      // This will always trigger a back transition
+      this.$router.directionOverride = -1
+
       // If we can go back - do so
       // otherwise if there's a default fall-back - use it
       // else - skip

--- a/src/router.js
+++ b/src/router.js
@@ -25,6 +25,9 @@ export default class Router extends globalVueRouter {
     // The direction user navigates in
     this.direction = args.direction || 1
 
+    // Override normal direction
+    this.directionOverride = null
+
     // Number of views navigated
     this.viewCount = args.viewCount || 0
 
@@ -40,13 +43,16 @@ export default class Router extends globalVueRouter {
 
     this.history.updateRoute = nextRoute => {
       // Guesstimate the direction of the next route
-      this.direction = this.guessDirection(nextRoute)
+      this.direction = this.directionOverride || this.guessDirection(nextRoute)
 
       // Increment or decrement the view count
       this.viewCount += this.direction
 
       // Call the original method
       this.history._updateRoute(nextRoute)
+
+      // Reset direction for overrides
+      this.directionOverride = null
     }
   }
   canGoBack() {

--- a/test/ion-vue-router.spec.js
+++ b/test/ion-vue-router.spec.js
@@ -51,7 +51,7 @@ describe('IonVueRouter', () => {
 
   it('Sets the default props correctly', () => {
     const constructor = Vue.extend(IonVueRouter)
-    const component = new constructor()
+    const component = new constructor({ router: new Router() })
     expect(component.bindCss).toBeFalsy()
     expect(component.animated).toBeTruthy()
     expect(component.name).toBe('default')
@@ -123,7 +123,7 @@ describe('IonVueRouter', () => {
 
   it('Runs stub methods correctly', () => {
     const constructor = Vue.extend(IonVueRouter)
-    const component = new constructor()
+    const component = new constructor({ router: new Router() })
 
     component.enterCancelled()
     component.leaveCancelled()


### PR DESCRIPTION
Doing so we can force a "back" navigation transition for the `default-href` attribute of `ion-back-button`
Before it was triggering a "forward" animation for routes other than `/`