### PR TITLE
Bump dependency versions in cookbook examples

### DIFF
--- a/cookbook/index.html
+++ b/cookbook/index.html
@@ -8,7 +8,7 @@
         <meta name="msapplication-tap-highlight" content="no">
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
-        <script src="https://unpkg.com/@modus/ionic-vue@1.0.4/dist/ionic-vue.js"></script>
+        <script src="https://unpkg.com/@modus/ionic-vue@1.0.5/dist/ionic-vue.js"></script>
         <script src="https://unpkg.com/@ionic/core@4.0.0-beta.2/dist/ionic.js"></script>
         <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.2/css/ionic.min.css"/>
     </head>

--- a/cookbook/index.html
+++ b/cookbook/index.html
@@ -8,9 +8,9 @@
         <meta name="msapplication-tap-highlight" content="no">
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
-        <script src="https://unpkg.com/@modus/ionic-vue@1.0.0/dist/ionic-vue.js"></script>
-        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.0/dist/ionic.js"></script>
-        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.0/css/ionic.min.css"/>
+        <script src="https://unpkg.com/@modus/ionic-vue@1.0.4/dist/ionic-vue.js"></script>
+        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.2/dist/ionic.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.2/css/ionic.min.css"/>
     </head>
 
     <body>

--- a/cookbook/ion-nav-routing.html
+++ b/cookbook/ion-nav-routing.html
@@ -8,7 +8,7 @@
         <meta name="msapplication-tap-highlight" content="no">
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
-        <script src="https://unpkg.com/@modus/ionic-vue@1.0.4/dist/ionic-vue.js"></script>
+        <script src="https://unpkg.com/@modus/ionic-vue@1.0.5/dist/ionic-vue.js"></script>
         <script src="https://unpkg.com/@ionic/core@4.0.0-beta.2/dist/ionic.js"></script>
         <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.2/css/ionic.min.css"/>
     </head>

--- a/cookbook/ion-nav-routing.html
+++ b/cookbook/ion-nav-routing.html
@@ -8,9 +8,9 @@
         <meta name="msapplication-tap-highlight" content="no">
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
-        <script src="https://unpkg.com/@modus/ionic-vue@1.0.0/dist/ionic-vue.js"></script>
-        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.0/dist/ionic.js"></script>
-        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.0/css/ionic.min.css"/>
+        <script src="https://unpkg.com/@modus/ionic-vue@1.0.4/dist/ionic-vue.js"></script>
+        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.2/dist/ionic.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.2/css/ionic.min.css"/>
     </head>
 
     <body>

--- a/cookbook/named-views.html
+++ b/cookbook/named-views.html
@@ -8,7 +8,7 @@
         <meta name="msapplication-tap-highlight" content="no">
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
-        <script src="https://unpkg.com/@modus/ionic-vue@1.0.4/dist/ionic-vue.js"></script>
+        <script src="https://unpkg.com/@5odus/ionic-vue@1.0.5/dist/ionic-vue.js"></script>
         <script src="https://unpkg.com/@ionic/core@4.0.0-beta.2/dist/ionic.js"></script>
         <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.2/css/ionic.min.css"/>
     </head>

--- a/cookbook/named-views.html
+++ b/cookbook/named-views.html
@@ -8,7 +8,7 @@
         <meta name="msapplication-tap-highlight" content="no">
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
-        <script src="https://unpkg.com/@5odus/ionic-vue@1.0.5/dist/ionic-vue.js"></script>
+        <script src="https://unpkg.com/@modus/ionic-vue@1.0.5/dist/ionic-vue.js"></script>
         <script src="https://unpkg.com/@ionic/core@4.0.0-beta.2/dist/ionic.js"></script>
         <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.2/css/ionic.min.css"/>
     </head>

--- a/cookbook/named-views.html
+++ b/cookbook/named-views.html
@@ -8,9 +8,9 @@
         <meta name="msapplication-tap-highlight" content="no">
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
-        <script src="https://unpkg.com/@modus/ionic-vue@1.0.0/dist/ionic-vue.js"></script>
-        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.0/dist/ionic.js"></script>
-        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.0/css/ionic.min.css"/>
+        <script src="https://unpkg.com/@modus/ionic-vue@1.0.4/dist/ionic-vue.js"></script>
+        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.2/dist/ionic.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.2/css/ionic.min.css"/>
     </head>
 
     <body>


### PR DESCRIPTION
Please do not merge yet, as I'd like to update to 1.0.5 after we release #14 