### PR TITLE
Mixed transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ It is an extension of the Vue Router thus it can be used as a drop-in replacemen
 - [Named views with transitions](cookbook/named-views-transitions.html)
 - [IonNav routing](cookbook/ion-nav-routing.html)
 - [Custom transitions](cookbook/custom-transitions.html)
+- [Mix Ionic and custom transitions](cookbook/mixed-transitions.html)
 
 ## Developing
 

--- a/cookbook/mixed-transitions.html
+++ b/cookbook/mixed-transitions.html
@@ -12,11 +12,15 @@
         <script src="https://unpkg.com/@ionic/core@4.0.0-beta.2/dist/ionic.js"></script>
         <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.2/css/ionic.min.css"/>
         <style>
-            .fade-enter-active, .fade-leave-active {
-                transition: all 1s ease;
+            /* hide the nasty black BG on ios */
+            .show-decor .nav-decor {
+                background: transparent !important;
             }
-            .fade-enter, .fade-leave-to {
-                opacity: 0
+            .slide-enter-active, .slide-leave-active {
+                transition: margin 1s ease;
+            }
+            .slide-enter, .slide-leave-to {
+                margin-top: 1000px;
             }
         </style>
     </head>
@@ -41,16 +45,16 @@
             })
 
             const Home = {
-                template: `<ion-page class="ion-page">
+                template: `<transition name="slide"><ion-page class="ion-page">
                     <toolbar title="Home"/>
                     <ion-content class="ion-content" padding>
                         <router-link to="/page">Go to page</router-link>
                     </ion-content>
-                </ion-page>`
+                </ion-page></transition>`
             }
 
             const Page = {
-                template: `<transition name="fade">
+                template: `<transition name="slide">
                     <ion-page class="ion-page">
                         <toolbar title="Page" backURL="/"/>
                         <ion-content class="ion-content" padding>

--- a/cookbook/mixed-transitions.html
+++ b/cookbook/mixed-transitions.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Ionic v4 + Vue.js - Basic routing</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="format-detection" content="telephone=no">
+        <meta name="msapplication-tap-highlight" content="no">
+        <script src="https://unpkg.com/vue"></script>
+        <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
+        <script src="https://unpkg.com/@modus/ionic-vue@latest/dist/ionic-vue.js"></script>
+        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.2/dist/ionic.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.2/css/ionic.min.css"/>
+        <style>
+            .fade-enter-active, .fade-leave-active {
+                transition: all 1s ease;
+            }
+            .fade-enter, .fade-leave-to {
+                opacity: 0
+            }
+        </style>
+    </head>
+
+    <body>
+        <ion-app>
+            <ion-vue-router></ion-vue-router>
+        </ion-app>
+
+        <script>
+            const Toolbar = Vue.component('Toolbar', {
+                name: 'Toolbar',
+                props: { title: String, backURL: String },
+                template: `<ion-header>
+                    <ion-toolbar>
+                        <ion-buttons slot="start">
+                            <ion-back-button :default-href="backURL"/>
+                        </ion-buttons>
+                        <ion-title>{{ title }}</ion-title>
+                    </ion-toolbar>
+                </ion-header>`
+            })
+
+            const Home = {
+                template: `<ion-page class="ion-page">
+                    <toolbar title="Home"/>
+                    <ion-content class="ion-content" padding>
+                        <router-link to="/page">Go to page</router-link>
+                    </ion-content>
+                </ion-page>`
+            }
+
+            const Page = {
+                template: `<transition name="fade">
+                    <ion-page class="ion-page">
+                        <toolbar title="Page" backURL="/"/>
+                        <ion-content class="ion-content" padding>
+                            <ion-button @click="goHome">Go home</ion-button>
+                        </ion-content>
+                    </ion-page>
+                </transition>`,
+                methods: {
+                    goHome() {
+                        this.$router.back()
+                    }
+                }
+            }
+
+            Vue.config.ignoredElements.push(/^ion-/)
+
+            new Vue({
+                router: new IonicVue.IonicVueRouter({
+                    routes: [
+                        { path: '/', component: Home },
+                        { path: '/page', meta: { customTransition: true }, component: Page },
+                    ],
+                }),
+            }).$mount('ion-app')
+        </script>
+    </body>
+</html>

--- a/cookbook/mixed-transitions.html
+++ b/cookbook/mixed-transitions.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>Ionic v4 + Vue.js - Basic routing</title>
+        <title>Ionic v4 + Vue.js - Mixed transitions</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="format-detection" content="telephone=no">
         <meta name="msapplication-tap-highlight" content="no">

--- a/src/components/ion-vue-router.vue
+++ b/src/components/ion-vue-router.vue
@@ -2,7 +2,11 @@
   <ion-router-outlet
     ref="ionRouterOutlet"
     @click="catchIonicGoBack">
+    <router-view
+      v-if="customTransition"
+      :name="name"/>
     <transition
+      v-else
       :css="bindCSS"
       mode="in-out"
       @before-enter="beforeEnter"
@@ -52,12 +56,17 @@ export default {
 
       // Flag to see if we're still in a transition
       inTransition: false,
+
+      customTransition: false,
     }
   },
   created() {
     // Cancel navigation if there's a running transition
     this.$router.beforeEach((to, from, next) => {
-      return next(!this.inTransition)
+      this.customTransition = to.meta.customTransition || false
+      return this.$nextTick(() => {
+        return next(!this.inTransition)
+      })
     })
   },
   methods: {

--- a/test/ion-vue-router-transitionless.spec.js
+++ b/test/ion-vue-router-transitionless.spec.js
@@ -1,0 +1,43 @@
+import Vue from 'vue'
+import Router from '../src/router.js'
+import IonVueRouterTransitionless from '../src/components/ion-vue-router-transitionless.vue'
+
+Vue.use(Router)
+
+describe('IonVueRouter', () => {
+  it('Catches back button click event', () => {
+    const constructor = Vue.extend(IonVueRouterTransitionless)
+    const component = new constructor({ router: new Router({ mode: 'abstract' }) })
+
+    expect(component.catchIonicGoBack({})).toBeFalsy()
+
+    component.$router.push('/')
+    component.$router.push('/foo')
+    expect(component.$route.fullPath).toBe('/foo')
+
+    // Go back
+    component.catchIonicGoBack(mockBackEvent('/'))
+    expect(component.$route.fullPath).toBe('/')
+
+    // Should not go back
+    component.catchIonicGoBack(mockBackEvent())
+    expect(component.$route.fullPath).toBe('/')
+
+    // Go back to default route
+    component.catchIonicGoBack(mockBackEvent('/bar'))
+    expect(component.$route.fullPath).toBe('/bar')
+  })
+})
+
+function mockBackEvent(route) {
+  return {
+    target: {
+      closest() {
+        return {
+          defaultHref: route,
+        }
+      },
+    },
+    preventDefault() {},
+  }
+}

--- a/test/ion-vue-router.spec.js
+++ b/test/ion-vue-router.spec.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import Router from '../src/router.js'
 import IonVueRouter from '../src/components/ion-vue-router.vue'
+import IonVueRouterTransitionless from '../src/components/ion-vue-router-transitionless.vue'
 
 describe('IonVueRouter', () => {
   Vue.use(Router)
@@ -58,7 +59,7 @@ describe('IonVueRouter', () => {
   })
 
   it('Catches back button click event', () => {
-    const constructor = Vue.extend(IonVueRouter)
+    const constructor = Vue.extend(IonVueRouterTransitionless)
     const component = new constructor({ router: new Router({ mode: 'abstract' }) })
 
     expect(component.catchIonicGoBack({})).toBeFalsy()

--- a/test/ion-vue-router.spec.js
+++ b/test/ion-vue-router.spec.js
@@ -1,7 +1,6 @@
 import Vue from 'vue'
 import Router from '../src/router.js'
 import IonVueRouter from '../src/components/ion-vue-router.vue'
-import IonVueRouterTransitionless from '../src/components/ion-vue-router-transitionless.vue'
 
 describe('IonVueRouter', () => {
   Vue.use(Router)
@@ -56,29 +55,6 @@ describe('IonVueRouter', () => {
     expect(component.bindCss).toBeFalsy()
     expect(component.animated).toBeTruthy()
     expect(component.name).toBe('default')
-  })
-
-  it('Catches back button click event', () => {
-    const constructor = Vue.extend(IonVueRouterTransitionless)
-    const component = new constructor({ router: new Router({ mode: 'abstract' }) })
-
-    expect(component.catchIonicGoBack({})).toBeFalsy()
-
-    component.$router.push('/')
-    component.$router.push('/foo')
-    expect(component.$route.fullPath).toBe('/foo')
-
-    // Go back
-    component.catchIonicGoBack(mockBackEvent('/'))
-    expect(component.$route.fullPath).toBe('/')
-
-    // Should not go back
-    component.catchIonicGoBack(mockBackEvent())
-    expect(component.$route.fullPath).toBe('/')
-
-    // Go back to default route
-    component.catchIonicGoBack(mockBackEvent('/bar'))
-    expect(component.$route.fullPath).toBe('/bar')
   })
 
   it('Transitions correctly', () => {
@@ -190,18 +166,5 @@ function mockIonRouterOutlet() {
         })
       })
     },
-  }
-}
-
-function mockBackEvent(route) {
-  return {
-    target: {
-      closest() {
-        return {
-          defaultHref: route,
-        }
-      },
-    },
-    preventDefault() {},
   }
 }


### PR DESCRIPTION
Allow users to mix Ionic and custom transitions. This is done via the meta property of the route:
```js
{ path: '/', component: Home },
{ path: '/page', meta: { customTransition: true }, component: Page },
```

The above will enable a custom defined Vue transition when navigating from Home to Page, but will trigger base Ionic transitions when going back.