### PR TITLE
Bump up ionic core to beta 4, update cookbook

### DIFF
--- a/cookbook/custom-transitions.html
+++ b/cookbook/custom-transitions.html
@@ -11,8 +11,8 @@
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
         <script src="https://unpkg.com/@modus/ionic-vue@latest/dist/ionic-vue.js"></script>
-        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.3/dist/ionic.js"></script>
-        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.3/css/ionic.min.css"/>
+        <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.min.css"/>
         <style>
             .fade-enter-active, .fade-leave-active {
                 transition: opacity .3s ease;

--- a/cookbook/index.html
+++ b/cookbook/index.html
@@ -9,8 +9,8 @@
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
         <script src="https://unpkg.com/@modus/ionic-vue@latest/dist/ionic-vue.js"></script>
-        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.3/dist/ionic.js"></script>
-        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.3/css/ionic.min.css"/>
+        <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.min.css"/>
     </head>
 
     <body>

--- a/cookbook/ion-nav-routing.html
+++ b/cookbook/ion-nav-routing.html
@@ -9,8 +9,8 @@
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
         <script src="https://unpkg.com/@modus/ionic-vue@latest/dist/ionic-vue.js"></script>
-        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.3/dist/ionic.js"></script>
-        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.3/css/ionic.min.css"/>
+        <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.min.css"/>
     </head>
 
     <body>

--- a/cookbook/mixed-transitions.html
+++ b/cookbook/mixed-transitions.html
@@ -9,8 +9,8 @@
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
         <script src="https://unpkg.com/@modus/ionic-vue@latest/dist/ionic-vue.js"></script>
-        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.3/dist/ionic.js"></script>
-        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.3/css/ionic.min.css"/>
+        <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.min.css"/>
         <style>
             /* hide the nasty black BG on ios */
             .show-decor .nav-decor {

--- a/cookbook/named-views-transitions.html
+++ b/cookbook/named-views-transitions.html
@@ -9,8 +9,8 @@
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
         <script src="https://unpkg.com/@modus/ionic-vue@latest/dist/ionic-vue.js"></script>
-        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.3/dist/ionic.js"></script>
-        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.3/css/ionic.min.css"/>
+        <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.min.css"/>
         <style>
             .fade-enter-active, .fade-leave-active {
                 transition: opacity .3s ease;

--- a/cookbook/named-views.html
+++ b/cookbook/named-views.html
@@ -9,8 +9,8 @@
         <script src="https://unpkg.com/vue"></script>
         <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script>
         <script src="https://unpkg.com/@modus/ionic-vue@latest/dist/ionic-vue.js"></script>
-        <script src="https://unpkg.com/@ionic/core@4.0.0-beta.3/dist/ionic.js"></script>
-        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@4.0.0-beta.3/css/ionic.min.css"/>
+        <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.min.css"/>
     </head>
 
     <body>

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "vue": "^2.5.16",
     "vue-template-compiler": "^2.5.16",
     "vue-router": "^3.0.1",
-    "@ionic/core": "4.0.0-beta.3"
+    "@ionic/core": "4.0.0-beta.4"
   },
   "jestSonar": {
     "reportPath": "reports",


### PR DESCRIPTION
- Update to ionic/core beta 4
- Update cookbook examples to use latest ionic/core