### PR TITLE
Allow HTML elements to be attached to DOM

### DIFF
--- a/src/framework-delegate.js
+++ b/src/framework-delegate.js
@@ -5,6 +5,16 @@ export default class Delegate {
 
   // Attach the passed Vue component to DOM
   attachViewToDom(parentElement, component, opts, classes) {
+    // Handle HTML elements
+    if (isElement(component)) {
+      // Add any classes to the Vue component's root element
+      addClasses(component, classes)
+
+      // Append the Vue component to DOM
+      parentElement.appendChild(component)
+      return Promise.resolve(component)
+    }
+
     // Get the Vue controller
     return this.vueController(component).then(controller => {
       const vueComponent = this.vueComponent(controller, opts)
@@ -43,12 +53,20 @@ export default class Delegate {
   }
 }
 
+// Check Symbol support
 const hasSymbol = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol'
 
+// Check if object is an ES module
 function isESModule(obj) {
   return obj.__esModule || (hasSymbol && obj[Symbol.toStringTag] === 'Module')
 }
 
+// Check if value is an Element
+function isElement(el) {
+  return typeof Element !== 'undefined' && el instanceof Element
+}
+
+// Add an array of classes to an element
 function addClasses(element, classes = []) {
   for (const cls of classes) {
     element.classList.add(cls)

--- a/src/framework-delegate.js
+++ b/src/framework-delegate.js
@@ -7,10 +7,10 @@ export default class Delegate {
   attachViewToDom(parentElement, component, opts, classes) {
     // Handle HTML elements
     if (isElement(component)) {
-      // Add any classes to the Vue component's root element
+      // Add any classes to the element
       addClasses(component, classes)
 
-      // Append the Vue component to DOM
+      // Append the element to DOM
       parentElement.appendChild(component)
       return Promise.resolve(component)
     }

--- a/test/framework-delegate.node.spec.js
+++ b/test/framework-delegate.node.spec.js
@@ -1,9 +1,0 @@
-import Vue from 'vue'
-
-describe('Framework delegation node', () => {
-  it('Sets globals correctly', () => {
-    window.Vue = undefined
-    global.Vue = Vue
-    require('../src/framework-delegate.js')
-  })
-})

--- a/test/framework-delegate.spec.js
+++ b/test/framework-delegate.spec.js
@@ -52,6 +52,15 @@ describe('Framework delegation', () => {
     })
   })
 
+  it('Attaches HTML elements to DOM', () => {
+    expect.assertions(1)
+    const element = document.createElement('p')
+
+    return delegate.attachViewToDom(app, element, null, ['foo']).then(el => {
+      return expect(el.classList.contains('foo')).toBeTruthy()
+    })
+  })
+
   it('Removes from DOM', () => {
     expect.assertions(2)
     const div = document.querySelector('p')


### PR DESCRIPTION
Allow HTML elements to be attached to DOM, for example:
```js
Vue.component('foo', {
  template: '<p>bar</p>',
  mounted() {
    this.$ionic.modalController.create({ component: this.$el }).then(m => m.present())
  }
}
```

Also remove the no longer used node variant of framework delegation test