### PR TITLE
Fix transition direction bug

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -33,7 +33,12 @@ export default class Router extends _VueRouter {
 
     this.history.updateRoute = nextRoute => {
       // Guesstimate the direction of the next route
-      this.direction = this.directionOverride || this.guessDirection(nextRoute)
+      this.direction = this.guessDirection(nextRoute)
+
+      // Override the direction
+      if (this.directionOverride) {
+        this.direction = this.directionOverride
+      }
 
       // Increment or decrement the view count
       this.viewCount += this.direction


### PR DESCRIPTION
As per bug report here: https://github.com/ModusCreateOrg/beep/issues/77

The direction override placed on the ionic's back button was not allowing for the route stack to be updated